### PR TITLE
fix: include armv7l in spidev platform marker

### DIFF
--- a/software/containers/telescope_api/hardware_interface/setup.py
+++ b/software/containers/telescope_api/hardware_interface/setup.py
@@ -11,7 +11,7 @@ setup(
     long_description_content_type="text/markdown",
     packages=["tart_hardware_interface"],
     install_requires=[
-        "spidev; platform_machine=='aarch64'",
+        "spidev; platform_machine=='aarch64' or platform_machine=='armv7l'",
         "numpy",
         "tart",
         "requests",

--- a/software/containers/telescope_api/tart_api/pyproject.toml
+++ b/software/containers/telescope_api/tart_api/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "h5py>=3.14.0",
     "tart>=1.3.1",
     "requests>=2.28.0",
-    "spidev>=3.1.0; platform_machine == 'aarch64'",
+    "spidev>=3.1.0; platform_machine == 'aarch64' or platform_machine == 'armv7l'",
     "tart-hardware-interface",
 ]
 

--- a/software/containers/telescope_api/tart_api/uv.lock
+++ b/software/containers/telescope_api/tart_api/uv.lock
@@ -1346,7 +1346,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "python-jose", extra = ["cryptography"] },
     { name = "requests" },
-    { name = "spidev", marker = "platform_machine == 'aarch64'" },
+    { name = "spidev", marker = "platform_machine == 'aarch64' or platform_machine == 'armv7l'" },
     { name = "tart" },
     { name = "tart-hardware-interface" },
     { name = "uvicorn", extra = ["standard"] },
@@ -1375,7 +1375,7 @@ requires-dist = [
     { name = "python-jose", extras = ["cryptography"], specifier = ">=3.3.0" },
     { name = "requests", specifier = ">=2.28.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
-    { name = "spidev", marker = "platform_machine == 'aarch64'", specifier = ">=3.1.0" },
+    { name = "spidev", marker = "platform_machine == 'aarch64' or platform_machine == 'armv7l'", specifier = ">=3.1.0" },
     { name = "tart", specifier = ">=1.3.1" },
     { name = "tart-hardware-interface", directory = "../hardware_interface" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.24.0" },
@@ -1389,7 +1389,7 @@ source = { directory = "../hardware_interface" }
 dependencies = [
     { name = "numpy" },
     { name = "requests" },
-    { name = "spidev", marker = "platform_machine == 'aarch64'" },
+    { name = "spidev", marker = "platform_machine == 'aarch64' or platform_machine == 'armv7l'" },
     { name = "tart" },
 ]
 
@@ -1398,7 +1398,7 @@ requires-dist = [
     { name = "matplotlib", marker = "extra == 'test'" },
     { name = "numpy" },
     { name = "requests" },
-    { name = "spidev", marker = "platform_machine == 'aarch64'" },
+    { name = "spidev", marker = "platform_machine == 'aarch64' or platform_machine == 'armv7l'" },
     { name = "tart" },
 ]
 provides-extras = ["test"]


### PR DESCRIPTION
spidev was only installed when platform_machine == 'aarch64' (64-bit ARM). On a Pi 3 running 32-bit ARMv7, platform_machine reports 'armv7l', so spidev was silently skipped during the linux/arm/v7 image build.

This adds 'armv7l' to the platform_machine marker in pyproject.toml, setup.py, and regenerates uv.lock.