### PR TITLE
feat: add piwheels index for pre-built armv7l wheels

### DIFF
--- a/software/containers/telescope_api/Dockerfile
+++ b/software/containers/telescope_api/Dockerfile
@@ -1,6 +1,6 @@
 # Build stage
 FROM python:3.13-trixie AS builder
-RUN apt-get update && apt-get install -y libhdf5-dev && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y libhdf5-dev libopenblas-dev && rm -rf /var/lib/apt/lists/*
 ADD https://astral.sh/uv/install.sh /uv-installer.sh
 RUN sh /uv-installer.sh && rm /uv-installer.sh
 ENV PATH="/root/.local/bin/:$PATH"
@@ -49,7 +49,7 @@ RUN mkdir -p /database
 # Set working directory
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y libhdf5-dev && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y libhdf5-dev libopenblas0 && rm -rf /var/lib/apt/lists/*
 
 # Copy virtual environment from builder
 COPY --from=builder /opt/venv /opt/venv

--- a/software/containers/telescope_api/Dockerfile
+++ b/software/containers/telescope_api/Dockerfile
@@ -7,6 +7,7 @@ ENV PATH="/root/.local/bin/:$PATH"
 
 WORKDIR /app
 ENV UV_LINK_MODE=copy
+ENV UV_EXTRA_INDEX_URL=https://www.piwheels.org/simple
 ENV UV_PROJECT_ENVIRONMENT=/opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 ENV VIRTUAL_ENV=/opt/venv


### PR DESCRIPTION
Adds UV_EXTRA_INDEX_URL=https://www.piwheels.org/simple to the builder stage so uv can pull pre-built armv7l wheels instead of compiling from source during linux/arm/v7 Docker builds.